### PR TITLE
Terraform templates for Lustre on Azure

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This project includes the following:
 
 * A [packer](https://www.packer.io/) script to build an image with the Lustre packages installed.
 * An [ARM template](https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/) to deploy a Lustre cluster using the image.
+* A [Terraform template](terraform/README.md) to deploy a Lustre cluster automatically based on a marketplace image.
 
 The ARM template performs the installation with [cloud init](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/using-cloud-init) where the installation scripts are embedded.  The `azuredeploy.json` includes the embedded scripts but the repo includes script to create this from the `azuredeploy_template.json`.
 

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,34 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
+#
+*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -32,3 +32,5 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+.terraform.lock.hcl
+*.plan

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,57 @@
+# Terraform templates for deploying Lustre on Azure
+
+**These templates are still being actively developed.**
+
+## Introduction
+
+These templates can be used to built a ready to go Lustre cluster on Azure compute. The goal is to have templates that provide low friction and make it easy to start using Lustre for workloads like SAS.
+
+What this template accomplishes:
+
+- Sets up a MGS and MDS node with a P30 disk attached to it
+- Sets up multiple OSS nodes with one more disks attached to it. Configured with mdadm they are exposed as OSS nodes to the MGS
+- Sets up a jumpbox that has the Lustre filesystem automatically mounted
+
+The default sizing is using 2x `Standard_D32s_v3` with 4x Premium P30 disks 1TB disks. This yields 4TB of Lustre per OSS node with 3.8TB usable for a total of 7.6TB. Sizing for Lustre is very important and our recommendation is to scale out before scaling up. For example, a cluster with 12x `Standard_D32s_v3` machines can drive more throughput than a cluster with 6x `Standard_D64s_v3` machines. When using larger files do consider striping data to remove some dependencies on specific nodes being a bottleneck.
+
+This deployment uses your local SSH keys to set up the access, copying your public key to MDS, OSS and jumpbox.
+
+## Variables
+
+You can specify variables in `variables.tf` to customize your deployment. The following variables are currently provided:
+
+| Name of variable       | Description of variable                                              |
+|------------------------|----------------------------------------------------------------------|
+| oss-nodes.sku          | The VM type for the OSS (data) nodes to use                          |
+| oss-nodes.total        | Total number of OSS (data) VMs that will be created for Lustre       |
+| oss-nodes-disks.size   | Size of the disk to use, always use full disk size provided by Azure |
+| oss-nodes-disks.sku    | Premium_LRS, Standard_LRS, StandardSSD_LRS                           |
+| oss-nodes-disks.total  | Total disks is total size of per node data (total*size)              |
+| lustre-filesystem-name | The name of te filesystem to mount (ip@tcp:/{fsname})                |
+| lustre-version         | Version of Lustre to use, we tested with 2.12.6                      |
+
+## How to deploy
+
+1. Run `az login`
+2. In the directory, run `terraform plan`
+3. Apply the plan using `terraform apply -parallelism=30` you can change the parallelism. A value of $oss_nodes * $disks_per_oss is recommended (e.g. 12x4 => 48) to accelerate deployment of all the disks for the VMs.
+4. Wait for Terraform to complete and 5 minutes later run `az vm list-ip-addresses -o table` and take note of the public IP address of the jumpbox.
+5. Use an SSH client to connect to the jumpbox with `ssh lustre@<ip>` and check out the lustre filesystem on `/lustre` or checkout `lfs df -h`
+
+To SSH to the OSS or MGS nodes, please scp/sftp your private key to the jumpbox and hop from there to the node.
+
+Recommended Lustre client tuning for optimal performance is:
+
+```bash
+lctl set_param mdc.*.max_rpcs_in_flight=128 osc.*.max_rpcs_in_flight=16 osc.*.max_dirty_mb=1024 llite.*.max_read_ahead_mb=2048 osc.*.checksums=0  llite.*.max_read_ahead_per_file_mb=256
+```
+
+## Goals/plans moving forward
+
+1. Make these templates more modular so that you can drop in other existing components much easier (e.g. existing VNet and adding Lustre clients or OSS nodes)
+2. Setup HSM and deploy a copytool on the Jumpbox to move data in and out of Lustre on demand
+3. Add High Availability options to MSG and MDS nodes.
+4. Add High Availability options to OSS nodes.
+5. Integrate LogAnalytics
+6. Provide some standard t-shirt size variable set ups
+7. Add an introduction to Lustre for non-Lustre people

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -52,9 +52,9 @@ resource "azurerm_network_interface" "mds" {
   resource_group_name = azurerm_resource_group.lustre.name
 
   ip_configuration {
-    name                                    = "ipconfig-mds-1-nic"
-    subnet_id                               = azurerm_subnet.client.id
-    private_ip_address_allocation           = "Dynamic"
+    name                          = "ipconfig-mds-1-nic"
+    subnet_id                     = azurerm_subnet.client.id
+    private_ip_address_allocation = "Dynamic"
   }
 }
 
@@ -66,8 +66,8 @@ resource "azurerm_linux_virtual_machine" "mds" {
   size                  = "Standard_D16s_v3"
 
   os_disk {
-    name              = "lustre-mds-1-os"
-    caching           = "ReadWrite"
+    name                 = "lustre-mds-1-os"
+    caching              = "ReadWrite"
     storage_account_type = "Premium_LRS"
   }
 
@@ -83,8 +83,8 @@ resource "azurerm_linux_virtual_machine" "mds" {
   disable_password_authentication = true
 
   admin_ssh_key {
-    username       = "lustre"
-    public_key     = file("~/.ssh/id_rsa.pub")
+    username   = "lustre"
+    public_key = file("~/.ssh/id_rsa.pub")
   }
 
   boot_diagnostics {
@@ -116,9 +116,9 @@ resource "azurerm_network_interface" "mgs" {
   resource_group_name = azurerm_resource_group.lustre.namey
 
   ip_configuration {
-    name                                    = "ipconfig-mgs-1-nic"
-    subnet_id                               = azurerm_subnet.client.id
-    private_ip_address_allocation           = "Dynamic"
+    name                          = "ipconfig-mgs-1-nic"
+    subnet_id                     = azurerm_subnet.client.id
+    private_ip_address_allocation = "Dynamic"
   }
 }
 
@@ -146,8 +146,8 @@ resource "azurerm_linux_virtual_machine" "mgs" {
   size                  = "Standard_D16s_v3"
 
   os_disk {
-    name              = "lustre-mgs-1-os"
-    caching           = "ReadWrite"
+    name                 = "lustre-mgs-1-os"
+    caching              = "ReadWrite"
     storage_account_type = "Premium_LRS"
   }
 
@@ -163,8 +163,8 @@ resource "azurerm_linux_virtual_machine" "mgs" {
   disable_password_authentication = true
 
   admin_ssh_key {
-    username       = "lustre"
-    public_key     = file("~/.ssh/id_rsa.pub")
+    username   = "lustre"
+    public_key = file("~/.ssh/id_rsa.pub")
   }
 
   boot_diagnostics {
@@ -181,9 +181,9 @@ resource "azurerm_network_interface" "oss" {
   count               = var.oss-nodes
 
   ip_configuration {
-    name                                    = "ipconfig-oss-nic-${count.index}"
-    subnet_id                               = azurerm_subnet.client.id
-    private_ip_address_allocation           = "Dynamic"
+    name                          = "ipconfig-oss-nic-${count.index}"
+    subnet_id                     = azurerm_subnet.client.id
+    private_ip_address_allocation = "Dynamic"
   }
 }
 
@@ -196,8 +196,8 @@ resource "azurerm_linux_virtual_machine" "oss" {
   size                  = "Standard_D32s_v3"
 
   os_disk {
-    name              = "lustre-oss-${count.index}-os"
-    caching           = "ReadWrite"
+    name                 = "lustre-oss-${count.index}-os"
+    caching              = "ReadWrite"
     storage_account_type = "Premium_LRS"
   }
 
@@ -213,8 +213,8 @@ resource "azurerm_linux_virtual_machine" "oss" {
   disable_password_authentication = true
 
   admin_ssh_key {
-    username       = "lustre"
-    public_key     = file("~/.ssh/id_rsa.pub")
+    username   = "lustre"
+    public_key = file("~/.ssh/id_rsa.pub")
   }
 
   boot_diagnostics {
@@ -286,8 +286,8 @@ resource "azurerm_linux_virtual_machine" "jump" {
   size                  = "Standard_D2s_v3"
 
   os_disk {
-    name              = "lustre-jump-server-os"
-    caching           = "ReadWrite"
+    name                 = "lustre-jump-server-os"
+    caching              = "ReadWrite"
     storage_account_type = "Premium_LRS"
   }
 
@@ -303,8 +303,8 @@ resource "azurerm_linux_virtual_machine" "jump" {
   disable_password_authentication = true
 
   admin_ssh_key {
-    username       = "lustre"
-    public_key     = file("~/.ssh/id_rsa.pub")
+    username   = "lustre"
+    public_key = file("~/.ssh/id_rsa.pub")
   }
 
   boot_diagnostics {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,318 @@
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "lustre" {
+  name = "azlustre"
+  location = "northcentralus"
+  tags = {
+      project = "lustre"
+      owner = "ronieuwe"
+  }
+}
+
+resource "random_id" "storage_gen_name" {
+  byte_length = 8
+}
+
+resource "azurerm_storage_account" "stor" {
+  name                     = "lustre${lower(replace(random_id.storage_gen_name.b64_url, "/[-_=]/", ""))}"
+  location                 = azurerm_resource_group.lustre.location
+  resource_group_name      = azurerm_resource_group.lustre.name
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_virtual_network" "lustre" {
+  name                = "lustre-net"
+  address_space       = ["10.10.0.0/16"]
+  location            = azurerm_resource_group.lustre.location
+  resource_group_name = azurerm_resource_group.lustre.name
+}
+
+resource "azurerm_subnet" "cluster" {
+  name                 = "cluster"
+  resource_group_name  = azurerm_resource_group.lustre.name
+  virtual_network_name = azurerm_virtual_network.lustre.name
+  address_prefixes     = ["10.10.2.0/23"]
+}
+
+resource "azurerm_subnet" "client" {
+  name                 = "clients"
+  resource_group_name  = azurerm_resource_group.lustre.name
+  virtual_network_name = azurerm_virtual_network.lustre.name
+  address_prefixes     = ["10.10.4.0/23"]
+}
+
+## Section for MDS
+
+resource "azurerm_network_interface" "mds" {
+  name                = "lustre-mds-1-nic"
+  location            = azurerm_resource_group.lustre.location
+  resource_group_name = azurerm_resource_group.lustre.name
+
+  ip_configuration {
+    name                                    = "ipconfig-mds-1-nic"
+    subnet_id                               = azurerm_subnet.client.id
+    private_ip_address_allocation           = "Dynamic"
+  }
+}
+
+resource "azurerm_linux_virtual_machine" "mds" {
+  name                  = "lustre-mds-1"
+  location              = azurerm_resource_group.lustre.location
+  resource_group_name   = azurerm_resource_group.lustre.name
+  network_interface_ids = [ azurerm_network_interface.mds.id ]
+  size                  = "Standard_D16s_v3"
+
+  os_disk {
+    name              = "lustre-mds-1-os"
+    caching           = "ReadWrite"
+    storage_account_type = "Premium_LRS"
+  }
+
+  source_image_reference {
+    publisher = "OpenLogic"
+    offer     = "CentOS"
+    sku       = "7.5"
+    version   = "latest"
+  }
+
+  computer_name  = "lustre-mds-1"
+  admin_username = "lustre"
+  disable_password_authentication = true
+
+  admin_ssh_key {
+    username       = "lustre"
+    public_key     = file("~/.ssh/id_rsa.pub")
+  }
+
+  boot_diagnostics {
+    storage_account_uri = azurerm_storage_account.stor.primary_blob_endpoint
+  }
+}
+
+resource "azurerm_managed_disk" "mds" {
+  name                 = "lustre-mds-1-data"
+  location             = azurerm_resource_group.lustre.location
+  create_option        = "Empty"
+  disk_size_gb         = 32
+  resource_group_name  = azurerm_resource_group.lustre.name
+  storage_account_type = "Standard_LRS"
+}
+
+resource "azurerm_virtual_machine_data_disk_attachment" "mds" {
+  virtual_machine_id = azurerm_linux_virtual_machine.mds.id
+  managed_disk_id    = azurerm_managed_disk.mds.id
+  lun                = 0
+  caching            = "None"
+}
+
+## Section for MGS
+
+resource "azurerm_network_interface" "mgs" {
+  name                = "lustre-mgs-1-nic"
+  location            = azurerm_resource_group.lustre.location
+  resource_group_name = azurerm_resource_group.lustre.namey
+
+  ip_configuration {
+    name                                    = "ipconfig-mgs-1-nic"
+    subnet_id                               = azurerm_subnet.client.id
+    private_ip_address_allocation           = "Dynamic"
+  }
+}
+
+resource "azurerm_managed_disk" "mgs" {
+  name                 = "lustre-mgs-1-data"
+  location             = azurerm_resource_group.lustre.location
+  create_option        = "Empty"
+  disk_size_gb         = 32
+  resource_group_name  = azurerm_resource_group.lustre.name
+  storage_account_type = "Standard_LRS"
+}
+
+resource "azurerm_virtual_machine_data_disk_attachment" "mgs" {
+  virtual_machine_id = azurerm_linux_virtual_machine.mgs.id
+  managed_disk_id    = azurerm_managed_disk.mgs.id
+  lun                = 0
+  caching            = "None"
+}
+
+resource "azurerm_linux_virtual_machine" "mgs" {
+  name                  = "lustre-mgs-1"
+  location              = azurerm_resource_group.lustre.location
+  resource_group_name   = azurerm_resource_group.lustre.name
+  network_interface_ids = [ azurerm_network_interface.mgs.id ]
+  size                  = "Standard_D16s_v3"
+
+  os_disk {
+    name              = "lustre-mgs-1-os"
+    caching           = "ReadWrite"
+    storage_account_type = "Premium_LRS"
+  }
+
+  source_image_reference {
+    publisher = "OpenLogic"
+    offer     = "CentOS"
+    sku       = "7.5"
+    version   = "latest"
+  }
+
+  computer_name  = "lustre-mgs-1"
+  admin_username = "lustre"
+  disable_password_authentication = true
+
+  admin_ssh_key {
+    username       = "lustre"
+    public_key     = file("~/.ssh/id_rsa.pub")
+  }
+
+  boot_diagnostics {
+    storage_account_uri = azurerm_storage_account.stor.primary_blob_endpoint
+  }
+}
+
+## Section for OSS
+
+resource "azurerm_network_interface" "oss" {
+  name                = "lustre-oss-nic${count.index}"
+  location            = azurerm_resource_group.lustre.location
+  resource_group_name = azurerm_resource_group.lustre.name
+  count               = var.oss-nodes
+
+  ip_configuration {
+    name                                    = "ipconfig-oss-nic-${count.index}"
+    subnet_id                               = azurerm_subnet.client.id
+    private_ip_address_allocation           = "Dynamic"
+  }
+}
+
+resource "azurerm_linux_virtual_machine" "oss" {
+  count                 = var.oss-nodes
+  name                  = "lustre-oss-${count.index}"
+  location              = azurerm_resource_group.lustre.location
+  resource_group_name   = azurerm_resource_group.lustre.name
+  network_interface_ids = [element(azurerm_network_interface.oss.*.id, count.index)]
+  size                  = "Standard_D32s_v3"
+
+  os_disk {
+    name              = "lustre-oss-${count.index}-os"
+    caching           = "ReadWrite"
+    storage_account_type = "Premium_LRS"
+  }
+
+  source_image_reference {
+    publisher = "OpenLogic"
+    offer     = "CentOS"
+    sku       = "7.5"
+    version   = "latest"
+  }
+
+  computer_name  = "lustre-oss-${count.index}"
+  admin_username = "lustre"
+  disable_password_authentication = true
+
+  admin_ssh_key {
+    username       = "lustre"
+    public_key     = file("~/.ssh/id_rsa.pub")
+  }
+
+  boot_diagnostics {
+    storage_account_uri = azurerm_storage_account.stor.primary_blob_endpoint
+  }
+}
+
+# Make map
+
+locals {
+  vm_datadiskdisk_count_map = { for k in range(0, var.oss-nodes)  : k => var.oss-nodes-disks }
+  luns                      = { for k in local.datadisk_lun_map : k.datadisk_name => k.lun }
+  datadisk_lun_map = flatten([
+    for vm_name, count in local.vm_datadiskdisk_count_map : [
+      for i in range(count) : {
+        datadisk_name = format("lustre-oss-%s-disk%02d", vm_name, i)
+        lun           = i
+      }
+    ]
+  ])
+}
+
+# Disk themselves, P30 disks, 200MB/s, 5000 IOPS. We attach them in the next step (post VM provision)
+resource "azurerm_managed_disk" "managed_disk" {
+  for_each             = toset([for j in local.datadisk_lun_map : j.datadisk_name])
+  name                 = each.key
+  location             = azurerm_resource_group.lustre.location
+  resource_group_name  = azurerm_resource_group.lustre.name
+  storage_account_type = "Standard_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = 1024
+}
+
+resource "azurerm_virtual_machine_data_disk_attachment" "managed_disk_attach" {
+  for_each           = toset([for j in local.datadisk_lun_map : j.datadisk_name])
+  managed_disk_id    = azurerm_managed_disk.managed_disk[each.key].id
+  virtual_machine_id = azurerm_linux_virtual_machine.oss[tonumber(element(split("-", each.key), 2))].id
+  lun                = lookup(local.luns, each.key)
+  caching            = "None"
+}
+
+## Section jump server
+
+resource "azurerm_network_interface" "jump" {
+  name                = "lustre-jump-server-nic"
+  location            = azurerm_resource_group.lustre.location
+  resource_group_name = azurerm_resource_group.lustre.name
+
+  ip_configuration {
+    name                          = "ipconfig-jump-server-nic"
+    subnet_id                     = azurerm_subnet.client.id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.jump.id
+  }
+}
+
+resource "azurerm_public_ip" "jump" {
+  name                = "lustre-jump-server-pip"
+  resource_group_name = azurerm_resource_group.lustre.name
+  location            = azurerm_resource_group.lustre.location
+  allocation_method   = "Dynamic"
+}
+
+resource "azurerm_linux_virtual_machine" "jump" {
+  name                  = "lustre-jump-server"
+  location              = azurerm_resource_group.lustre.location
+  resource_group_name   = azurerm_resource_group.lustre.name
+  network_interface_ids = [ azurerm_network_interface.jump.id ]
+  size                  = "Standard_D2s_v3"
+
+  os_disk {
+    name              = "lustre-jump-server-os"
+    caching           = "ReadWrite"
+    storage_account_type = "Premium_LRS"
+  }
+
+  source_image_reference {
+    publisher = "OpenLogic"
+    offer     = "CentOS"
+    sku       = "7.5"
+    version   = "latest"
+  }
+
+  computer_name  = "lustre-jump-server"
+  admin_username = "lustre"
+  disable_password_authentication = true
+
+  admin_ssh_key {
+    username       = "lustre"
+    public_key     = file("~/.ssh/id_rsa.pub")
+  }
+
+  boot_diagnostics {
+    storage_account_uri = azurerm_storage_account.stor.primary_blob_endpoint
+  }
+}
+
+output "jump_ip_addr" {
+  value = azurerm_public_ip.jump
+  description = "Public IP for the jump server, use SSH key to login"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -245,7 +245,8 @@ resource "azurerm_linux_virtual_machine" "jump" {
   computer_name  = "lustre-jump-server"
   admin_username = "lustre"
   disable_password_authentication = true
-
+  custom_data = base64encode(templatefile("scripts/lustre.tpl", { type = "CLIENT", index = 0, diskcount = 0, mgs_ip=azurerm_network_interface.mgs.private_ip_address, fs_name = var.lustre-filesystem-name, lustre_version = var.lustre-version }))
+  
   admin_ssh_key {
     username   = "lustre"
     public_key = file("~/.ssh/id_rsa.pub")
@@ -254,4 +255,9 @@ resource "azurerm_linux_virtual_machine" "jump" {
   boot_diagnostics {
     storage_account_uri = azurerm_storage_account.stor.primary_blob_endpoint
   }
+
+  depends_on = [ 
+    azurerm_network_interface.mgs,
+    azurerm_linux_virtual_machine.mgs
+  ]
 }

--- a/terraform/scripts/lustre.tpl
+++ b/terraform/scripts/lustre.tpl
@@ -59,7 +59,7 @@ add_to_fstab() {
 
 # Parameters to be set through TF
 node_type=${type}
-node_index=$((${index}))
+node_index=${index}
 node_type_disk_count=${diskcount}
 mgs_ip=${mgs_ip}
 file_system_name=${fs_name}

--- a/terraform/scripts/lustre.tpl
+++ b/terraform/scripts/lustre.tpl
@@ -253,7 +253,8 @@ install_lustre_client() {
 	mkdir -m0777 /lustre
 	lustre_location="$${mgs_ip}@tcp:/$${file_system_name}"
 
-	mount -t lustre $lustre_location /lustre
+	# We may need some time for lustre to come up
+	retry 10 mount -t lustre $lustre_location /lustre
 }
 
 

--- a/terraform/scripts/lustre.tpl
+++ b/terraform/scripts/lustre.tpl
@@ -1,0 +1,223 @@
+#!/bin/bash
+
+# Source can be found at https://github.com/Azure/azure-quickstart-templates/blob/master/intel-lustre-client-server/scripts/lustre.sh
+# * Modified to work with cloud-init
+# * TPL'd for Terraform templatefile functionality
+
+# Usage:
+# ./lustre_configure.sh -n MGS -i 0 -d 1 -m 10.1.0.4 -l 10.1.0.4 -f scratch
+# ./lustre_configure.sh -n MDS -i 1 -d 1 -m 10.1.0.4 -l 10.1.0.4 -f scratch
+# ./lustre_configure.sh -n OSS -i 1 -d 4 -m 10.1.0.4 -l 10.1.0.4 -f scratch
+
+log()
+{
+	echo "$1"
+	logger "$1"
+}
+
+# Initialize local variables
+# Get today's date into YYYYMMDD format
+NOW=$(date +"%Y%m%d")
+DEVICES_BLACKLIST="/dev/sda|/dev/sdb"
+DEVICES_LIST=($(ls -1 /dev/sd* | egrep -v "${DEVICES_BLACKLIST}" | egrep -v "[0-9]$"))
+
+# Parameters to be set through TF
+NODETYPE=${type}
+NODEINDEX=${index}
+NODETYPEDISKCOUNT=${diskcount}
+MGSIP=${mgs_ip}
+LOCALIP=${local_ip}
+FILESYSTEMNAME=${fs_name}
+
+fatal() {
+    msg=${1:-"Unknown Error"}
+    log "FATAL ERROR: $msg"
+    exit 1
+}
+
+# Retries a command on failure.
+# $1 - the max number of attempts
+# $2... - the command to run
+retry() {
+    local -r -i max_attempts="$1"; shift
+    local -r cmd="$@"
+    local -i attempt_num=1
+
+    until $cmd
+    do
+        if (( attempt_num == max_attempts ))
+        then
+            log "Command $cmd attempt $attempt_num failed and there are no more attempts left!"
+			return 1
+        else
+            log "Command $cmd attempt $attempt_num failed. Trying again in 5 + $attempt_num seconds..."
+            sleep $(( 5 + attempt_num++ ))
+        fi
+    done
+}
+
+# You must be root to run this script
+if [ "${UID}" -ne 0 ]; then
+    fatal "You must be root to run this script."
+fi
+
+if [[ -z ${NODETYPE} ]]; then
+    fatal "No node type specified, can't proceed."
+fi
+
+if [[ -z ${NODEINDEX} ]]; then
+    fatal "No node index specified, can't proceed."
+fi
+
+if [[ -z ${NODETYPEDISKCOUNT} ]]; then
+    fatal "No node type disk count specified, can't proceed."
+fi
+
+if [[ -z ${MGSIP} ]]; then
+    fatal "No MGS IP specified, can't proceed."
+fi
+
+if [[ -z ${LOCALIP} ]]; then
+    fatal "No local IP specified, can't proceed."
+fi
+
+if [[ -z ${FILESYSTEMNAME} ]]; then
+    fatal "No filesystem name specified, can't proceed."
+fi
+
+log "NOW=$NOW NODETYPE=$NODETYPE NODEINDEX=$NODEINDEX MGSIP=$MGSIP LOCALIP=$LOCALIP FILESYSTEMNAME=$FILESYSTEMNAME"
+
+add_to_fstab() {
+	device="${1}"
+	mount_point="${2}"
+	if grep -q "$device" /etc/fstab
+	then
+		log "Not adding $device to /etc/fstab (it's  already there)"
+	else
+		line="$device $mount_point lustre defaults,_netdev 0 0"
+		log "${line}"
+		echo -e "${line}" >> /etc/fstab
+	fi
+}
+
+create_mgs() {
+	log "Create MGS"
+
+	# Make MGS filesystem which is always on /dev/sdc of the MGS node
+	mkfs.lustre --fsname=$FILESYSTEMNAME --mgs --reformat /dev/sdc
+
+	uuid=$(blkid -o value -s UUID /dev/sdc)
+	log "MGS UUID=$uuid"
+
+	label=$(blkid -c/dev/null -o value -s LABEL /dev/sdc)
+	log "MGS LABEL=$label"
+
+	# Log device info
+	dumpe2fs -h /dev/sdc | logger
+
+	# Create mount directory
+	mount_point=/mnt/targets/$label
+	mkdir -p $mount_point
+	log "Created mount point directory $mount_point"
+
+	# Add to /etc/fstab so that mount persists across reboots
+	device_by_uuid="UUID=$uuid"
+	add_to_fstab $device_by_uuid $mount_point
+
+	retry 5 mount -a
+	log "Mounted /dev/sdc as $mount_point"
+}
+
+create_mds() {
+	log "Create MDS"
+
+	((index=$NODEINDEX*$NODETYPEDISKCOUNT))
+
+	for device in "${DEVICES_LIST[@]}";
+	do
+		log $device $index
+
+		mkfs.lustre --fsname=$FILESYSTEMNAME --mdt --mgsnode=$MGSIP --index=$index --reformat $device
+
+		# Disable MDS check of user being the same on the clients and MDS nodes
+		tunefs.lustre --param mdt.identity_upcall=NONE $device
+
+		uuid=$(blkid -o value -s UUID $device)
+		log "MDS UUID=$uuid"
+
+		label=$(blkid -c/dev/null -o value -s LABEL $device)
+		log "MDS LABEL=$label"
+
+		dumpe2fs -h $device | logger
+
+		# Create mount directory
+		mount_point=/mnt/targets/$label
+		mkdir -p $mount_point
+		log "Created mount point directory $mount_point"
+
+		# Mount the current device
+		mount -t lustre $device $mount_point
+
+		# Add to /etc/fstab so that mount persists across reboots
+		device_by_uuid="UUID=$uuid"
+		add_to_fstab $device_by_uuid $mount_point
+
+		((index=index+1))
+	done
+
+	# Mount everything based on what is defined in the /etc/fstab
+	retry 5 mount -a
+}
+
+create_oss() {
+	log "Create OSS"
+
+	((index=$NODEINDEX*$NODETYPEDISKCOUNT))
+
+	for device in "${DEVICES_LIST[@]}";
+	do
+		log $device $index
+
+		mkfs.lustre --fsname=$FILESYSTEMNAME --ost --mgsnode=$MGSIP --index=$index --reformat $device
+
+		uuid=$(blkid -o value -s UUID $device)
+		log "OSS UUID=$uuid"
+
+		label=$(blkid -c/dev/null -o value -s LABEL $device)
+		log "OSS LABEL=$label"
+
+		dumpe2fs -h $device | logger
+
+		# Create mount directory
+		mount_point=/mnt/targets/$label
+		mkdir -p $mount_point
+		log "Created mount point directory $mount_point"
+
+		# Mount the current device
+		mount -t lustre $device $mount_point
+
+		# Add to /etc/fstab so that mount persists across reboots
+		device_by_uuid="UUID=$uuid"
+		add_to_fstab $device_by_uuid $mount_point
+
+		((index=index+1))
+	done
+
+	# Random sleep to minimize chance of mount error
+	sleep $[ ( $RANDOM % 20 ) + 1]s
+
+	# Mount everything based on what is defined in the /etc/fstab
+	retry 5 mount -a
+}
+
+if [ "$NODETYPE" == "MGS" ]; then
+	create_mgs
+fi
+
+if [ "$NODETYPE" == "MDS" ]; then
+	create_mds
+fi
+
+if [ "$NODETYPE" == "OSS" ]; then
+	create_oss
+fi

--- a/terraform/scripts/lustre.tpl
+++ b/terraform/scripts/lustre.tpl
@@ -261,7 +261,7 @@ install_lustre_client() {
 
 setup_lustre_repositories
 
-if [ "$node_type" == "CLIENT"]; then
+if [ "$node_type" == "CLIENT" ]; then
 	install_lustre_client
 fi
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,9 +1,19 @@
 variable "oss-nodes" {
   description = "The number of OSS nodes"
-  default = 1
+  default = 4
 }
 
 variable "oss-nodes-disks" {
   description = "The number of OSS disks per node"
-  default = 1
+  default = 4
+}
+
+variable "lustre-filesystem-name" {
+  description = "Name of the filesystem to create on top of Lustre"
+  default = "lustrefs"
+}
+
+variable "lustre-version" {
+  description = "Version of Lustre to use - check https://downloads.whamcloud.com/public/lustre/"
+  default = "2.12.6"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,9 @@
+variable "oss-nodes" {
+  description = "The number of OSS nodes"
+  default = 1
+}
+
+variable "oss-nodes-disks" {
+  description = "The number of OSS disks per node"
+  default = 1
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,11 +1,28 @@
 variable "oss-nodes" {
-  description = "The number of OSS nodes"
-  default = 4
+  description = "The number and size of OSS nodes"
+  type = object({
+    sku   = string
+    total = number
+  })
+  default = { # Standard is a P30 disk
+    sku   = "Standard_D32s_v3"    
+    total = 2
+  }
+  
 }
 
 variable "oss-nodes-disks" {
-  description = "The number of OSS disks per node"
-  default = 4
+  description = "The SKU, size and IOPS of disktype to use. Standard_LRS=HDDs (S), StandardSSD_LRS=SSDs (E), Premium_LRS=SSDs (P)"
+  type = object({
+    size  = number
+    sku   = string
+    total = number
+  })
+  default = { # Default value is a P30 disk
+    size  = 1024
+    sku   = "Premium_LRS"
+    total = 4
+  }
 }
 
 variable "lustre-filesystem-name" {


### PR DESCRIPTION
### Terraform templates for deploying Lustre on Azure

- Sets up a MGS and MDS node with a P30 disk attached to it
- Sets up multiple OSS nodes with one more disks attached to it. Configured with mdadm they are exposed as OSS nodes to the MGS
- Sets up a jumpbox that has the Lustre filesystem automatically mounted

Default sizing is using 2 D32s_v3 with 4 P30 disks, yielding 4TB of Lustre with 3.8TB usable per node for a total of 7.6TB. This deployment uses your local SSH keys to set up the access. How to deploy (README next):

1. Run ```az login```
2. In the directory, run ```terraform plan```
3. Apply the plan using ```terraform apply -parallelism=30``` you can change the parallelism. A value of $oss_nodes * $disks_per_oss is recommended (e.g. 12x4 => 48).
4. Make coffee, ~10 min later run ```az vm list-ip-addresses -o table``` and note the IP of the jumpbox.
5. Get on the jumpbox with ```ssh lustre@<ip>``` and check out the lustre filesystem on ```/lustre``` or checkout ```lfs df -h```

To SSH to the OSS or MGS nodes, please scp/sftp your private key to the jumpbox and hop from there to the node.