### PR TITLE
add a check for ephemeral disk mount

### DIFF
--- a/scripts/setup_lustre.sh
+++ b/scripts/setup_lustre.sh
@@ -53,7 +53,11 @@ else
 		n_devices=$(echo $devices | wc -w)
 		echo "Using $n_devices NVME devices"
 	elif [ -e /dev/sdc ]; then
-		devices='/dev/sd[c-m]'
+		if [[ "$(df -h)" == *"dev/sdb"* ]]; then
+		   devices='/dev/sd[c-m]'
+		else 
+		   devices='/dev/sd[b-m]'
+		fi
 		n_devices=$(echo $devices | wc -w)
 		echo "Using $n_devices NVME devices"
 	elif [ -e /dev/sdb ]; then


### PR DESCRIPTION
for the case of a VM with no ephemeral disk, add a check for mounted `/dev/sdb` and set devices appropriately. 

If `/dev/sdb` is not mounted the devices available to Lustre should start with `/dev/sdb`