### PR TITLE
increase size/perf of Rbh disk

### DIFF
--- a/azuredeploy_template.json
+++ b/azuredeploy_template.json
@@ -366,7 +366,8 @@
                     "imageReference": "[variables('imageReference')]",
                     "osDisk": {
                         "createOption": "FromImage",
-                        "caching": "ReadWrite"
+                        "caching": "ReadWrite",
+                        "diskSizeGB": 256
                     }
                 },
                 "networkProfile": {


### PR DESCRIPTION
the default 32GB Premium SSD performance is too slow (120 IOPS/25MBps) for the database.  Bumping it to 256GB Premium SSD bumps the perf to 1100 IOPS and 125MBps.